### PR TITLE
Add support for BLS signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "ic-verify-bls-signature"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "A library for verifying BLS signatures"
+description = "A library for handling BLS signatures"
 
 [dependencies]
 bls12_381 = { version = "0.7", default-features = false, features = ["groups", "pairings", "alloc", "experimental"] }
@@ -13,3 +13,4 @@ lazy_static = "1"
 
 [dev-dependencies]
 hex = "0.4"
+rand = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,7 @@ description = "A library for handling BLS signatures"
 [dependencies]
 bls12_381 = { version = "0.7", default-features = false, features = ["groups", "pairings", "alloc", "experimental"] }
 pairing = "0.22"
-sha2 = "0.9"
 lazy_static = "1"
-
-[dev-dependencies]
-hex = "0.4"
 rand = "0.6"
+sha2 = "0.9"
+hex = "0.4"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 BLS signature utility crate
 =============================
 
-This is a simple Rust crate which can be used to sign and verify BLS signatures
+This is a simple Rust crate which can be used to create and verify BLS signatures
 over the BLS12-381 curve. This follows the
 [IETF draft for BLS signatures](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bls-signature/),
 using the "short signature" variation, where signatures are in G1 and

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-Verify BLS signatures
-=======================
+BLS signature utility crate
+=============================
 
-This is a simple Rust crate which can be used to verify BLS signatures.
-This follows the [IETF draft for BLS signatures](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bls-signature/),
-using the "short signature" variation where signatures are in G1 and
+This is a simple Rust crate which can be used to sign and verify BLS signatures
+over the BLS12-381 curve. This follows the
+[IETF draft for BLS signatures](https://datatracker.ietf.org/doc/draft-irtf-cfrg-bls-signature/),
+using the "short signature" variation, where signatures are in G1 and
 public keys are in G2.
+
+For historical reasons, this crate is named `ic-verify-bls-signature`,
+but it also supports signature generation.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,20 @@
+#![no_std]
 #![forbid(unsafe_code)]
 #![forbid(missing_docs)]
+#![allow(clippy::result_unit_err)]
 
 //! Verify BLS signatures
 //!
 //! This verifies BLS signatures in a manner which is compatible with
 //! the Internet Computer.
 
+use core::fmt;
+use core::ops::Neg;
+
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
 use bls12_381::{multi_miller_loop, G1Affine, G1Projective, G2Affine, G2Prepared, Scalar};
 use pairing::group::{Curve, Group};
-use std::ops::Neg;
+use rand::RngCore;
 
 lazy_static::lazy_static! {
     static ref G2PREPARED_NEG_G : G2Prepared = G2Affine::generator().neg().into();
@@ -25,56 +30,217 @@ fn hash_to_g1(msg: &[u8]) -> G1Affine {
     .to_affine()
 }
 
+/// A BLS12-381 public key usable for signature verification
+#[derive(Clone, Eq, PartialEq)]
+pub struct PublicKey {
+    pk: G2Affine,
+}
+
+impl fmt::Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PublicKey({})", hex::encode(self.serialize()))
+    }
+}
+
+/// An error indicating an encoded public key was not valid
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum InvalidPublicKey {
+    /// The public key encoding was not the correct length
+    WrongLength,
+    /// The public key was not a valid BLS12-381 G2 point
+    InvalidPoint,
+}
+
+impl PublicKey {
+    /// The length of the binary encoding of this type
+    pub const BYTES: usize = 96;
+
+    fn new(pk: G2Affine) -> Self {
+        Self { pk }
+    }
+
+    /// Return the serialization of this BLS12-381 public key
+    pub fn serialize(&self) -> [u8; Self::BYTES] {
+        self.pk.to_compressed()
+    }
+
+    /// Deserialize a BLS12-381 public key
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, InvalidPublicKey> {
+        let bytes: Result<[u8; Self::BYTES], _> = bytes.try_into();
+
+        match bytes {
+            Err(_) => Err(InvalidPublicKey::WrongLength),
+            Ok(b) => {
+                let pk = G2Affine::from_compressed(&b);
+                if bool::from(pk.is_some()) {
+                    Ok(Self::new(pk.unwrap()))
+                } else {
+                    Err(InvalidPublicKey::InvalidPoint)
+                }
+            }
+        }
+    }
+
+    /// Verify a BLS signature
+    pub fn verify(&self, message: &[u8], signature: &Signature) -> Result<(), ()> {
+        let msg = hash_to_g1(message);
+        let g2_gen: &G2Prepared = &G2PREPARED_NEG_G;
+        let pk = G2Prepared::from(self.pk);
+
+        let sig_g2 = (&signature.sig, g2_gen);
+        let msg_pk = (&msg, &pk);
+
+        let x = multi_miller_loop(&[sig_g2, msg_pk]).final_exponentiation();
+
+        if bool::from(x.is_identity()) {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+}
+
+/// An error indicating a signature could not be deserialized
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum InvalidSignature {
+    /// The signature encoding is the wrong length
+    WrongLength,
+    /// The signature encoding is not a valid BLS12-381 G1 point
+    InvalidPoint,
+}
+
+/// A type expressing a BLS12-381 signature
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct Signature {
+    sig: G1Affine,
+}
+
+impl fmt::Debug for Signature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Signature({})", hex::encode(self.serialize()))
+    }
+}
+
+impl Signature {
+    /// The length of the binary encoding of this type
+    pub const BYTES: usize = 48;
+
+    fn new(sig: G1Affine) -> Self {
+        Self { sig }
+    }
+
+    /// Serialize the BLS signature
+    pub fn serialize(&self) -> [u8; Self::BYTES] {
+        self.sig.to_compressed()
+    }
+
+    /// Deserialize a BLS signature
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, InvalidSignature> {
+        let bytes: Result<[u8; Self::BYTES], _> = bytes.try_into();
+
+        match bytes {
+            Err(_) => Err(InvalidSignature::WrongLength),
+            Ok(b) => {
+                let sig = G1Affine::from_compressed(&b);
+                if bool::from(sig.is_some()) {
+                    Ok(Self::new(sig.unwrap()))
+                } else {
+                    Err(InvalidSignature::InvalidPoint)
+                }
+            }
+        }
+    }
+}
+
+/// An error indicating a private key could not be deserialized
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum InvalidPrivateKey {
+    /// The secret key encoding was the wrong length and not possibly valid
+    WrongLength,
+    /// The secret key was outside the valid range of BLS12-381 keys
+    OutOfRange,
+}
+
+/// A type expressing a BLS12-381 private key
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct PrivateKey {
+    sk: Scalar,
+}
+
+impl fmt::Debug for PrivateKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "PrivateKey(REDACTED)")
+    }
+}
+
+impl PrivateKey {
+    /// The length of the serialized encoding of this type
+    pub const BYTES: usize = 32;
+
+    fn new(sk: Scalar) -> Self {
+        Self { sk }
+    }
+
+    /// Create a new random secret key
+    pub fn random() -> Self {
+        let mut rng = rand::thread_rng();
+
+        loop {
+            let mut buf = [0u8; 32];
+            rng.fill_bytes(&mut buf);
+            let s: Option<Scalar> = Scalar::from_bytes(&buf).into();
+
+            if let Some(s) = s {
+                return Self::new(s);
+            }
+        }
+    }
+
+    /// Serialize a private key to the binary big-ending encoding
+    pub fn serialize(&self) -> [u8; Self::BYTES] {
+        let mut bytes = self.sk.to_bytes();
+        bytes.reverse();
+        bytes
+    }
+
+    /// Deserialize a secret key
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, InvalidPrivateKey> {
+        let bytes: Result<[u8; Self::BYTES], _> = bytes.try_into();
+
+        match bytes {
+            Err(_) => Err(InvalidPrivateKey::WrongLength),
+            Ok(mut b) => {
+                b.reverse();
+                let sk = Scalar::from_bytes(&b);
+                if bool::from(sk.is_some()) {
+                    Ok(Self::new(sk.unwrap()))
+                } else {
+                    Err(InvalidPrivateKey::OutOfRange)
+                }
+            }
+        }
+    }
+
+    /// Return the public key associated with this secret key
+    pub fn public_key(&self) -> PublicKey {
+        PublicKey::new(G2Affine::from(G2Affine::generator() * self.sk))
+    }
+
+    /// Sign a message using this private key
+    ///
+    /// The message can be of arbitrary length
+    pub fn sign(&self, message: &[u8]) -> Signature {
+        let sig = hash_to_g1(message) * self.sk;
+        Signature::new(sig.to_affine())
+    }
+}
+
 /// Verify a BLS signature
 ///
 /// The signature must be exactly 48 bytes (compressed G1 element)
 /// The key must be exactly 96 bytes (compressed G2 element)
 pub fn verify_bls_signature(sig: &[u8], msg: &[u8], key: &[u8]) -> Result<(), ()> {
-    if sig.len() != 48 || key.len() != 96 {
-        return Err(());
-    }
-
-    let sig: Option<G1Affine> =
-        G1Affine::from_compressed(sig.try_into().expect("Checked length")).into();
-    let key: Option<G2Affine> =
-        G2Affine::from_compressed(key.try_into().expect("Checked length")).into();
-
-    let msg = hash_to_g1(msg);
-
-    match (sig, key) {
-        (Some(sig), Some(key)) => {
-            let g2_gen = &G2PREPARED_NEG_G;
-            let pub_key = G2Prepared::from(key);
-
-            let result =
-                multi_miller_loop(&[(&sig, &g2_gen), (&msg, &pub_key)]).final_exponentiation();
-
-            if bool::from(result.is_identity()) {
-                Ok(())
-            } else {
-                Err(())
-            }
-        }
-        (_, _) => Err(()),
-    }
-}
-
-/// Sign a message using BLS
-///
-/// The message can be of arbitrary length
-///
-/// The private key must be exactly 32 bytes (the big-endian encoding
-/// of the secret scalar)
-pub fn sign_message_with_bls(msg: &[u8], key: &[u8; 32]) -> Result<[u8; 48], ()> {
-    let mut le_bytes = key.clone();
-    le_bytes.reverse();
-    let key: Option<Scalar> = Scalar::from_bytes(&le_bytes).into();
-
-    if let Some(key) = key {
-        let msg = hash_to_g1(msg);
-        let sig = msg * key;
-        Ok(sig.to_affine().to_compressed())
-    } else {
-        Err(())
-    }
+    let sig = Signature::deserialize(sig).map_err(|_| ())?;
+    let pk = PublicKey::deserialize(key).map_err(|_| ())?;
+    pk.verify(msg, &sig)
 }


### PR DESCRIPTION
Adds specific types `PublicKey`, `PrivateKey`, and `Signature` which can handle operations including serialization, deserialization, key generation, signing, verification, and deriving public key from a private key. This should cover most needs for people developing applications outside DFINITY wrt handling of signatures.

The existing `verify_bls_signature`, which was previously the only public function in this crate, is now defined in terms of the new interfaces.