### PR TITLE
Update various dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ license = "Apache-2.0"
 description = "A library for handling BLS signatures"
 
 [dependencies]
-bls12_381 = { version = "0.7", default-features = false, features = ["groups", "pairings", "experimental"] }
-pairing = "0.22"
+bls12_381 = { version = "0.8", default-features = false, features = ["groups", "pairings", "experimental"] }
+pairing = "0.23"
 sha2 = { version = "0.9", default-features = false }
-rand = { version = "0.6", default-features = false }
+rand = { version = "0.8", default-features = false }
 
 lazy_static = { version = "1", optional = true }
 hex = { version = "0.4", optional = true, default-features = false }
@@ -20,4 +20,4 @@ alloc = ["bls12_381/alloc", "lazy_static", "hex/alloc"]
 
 [dev-dependencies]
 hex = "0.4"
-rand = "0.6"
+rand = "0.8"


### PR DESCRIPTION
Fixes #6

We can't upgrade `sha2` since `bls12_381` requires `sha2 0.9`