### PR TITLE
Bump ic_bls12_381 dep to 0.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "ic-verify-bls-signature"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for handling BLS signatures"
 
 [dependencies]
-bls12_381 = { version = "0.9", default-features = false, features = ["groups", "pairings", "experimental"], package = "ic_bls12_381" }
+bls12_381 = { version = "0.10", default-features = false, features = ["groups", "pairings", "experimental"], package = "ic_bls12_381" }
 pairing = "0.23"
 sha2 = { version = "0.10", default-features = false }
 rand = { version = "0.8", default-features = false }

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,12 @@
 
+# 0.5 - 2024-07-17
+
+* Bump `ic_bls12_381` dependency to 0.10
+
 # 0.4 - 2024-07-17
 
+* Yanked
 * Bump `sha2` dependency to 0.10
-* Bump `ic_bls12_381` dependency to 0.10
 
 # 0.3 - 2024-05-06
 


### PR DESCRIPTION
I released 0.4.0 of this crate thinking all was well - then realized I forgot to bump `ic_bls12_381` :sob: