### PR TITLE
feat: CRP-2575 Gate usage of `rand` crate behind feature "rand"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,5 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - run: cargo test
       - run: cargo test --no-default-features
+      - run: cargo test --no-default-features --features=alloc
+      - run: cargo test --no-default-features --features=rand

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-verify-bls-signature"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "A library for handling BLS signatures"
@@ -9,13 +9,14 @@ description = "A library for handling BLS signatures"
 bls12_381 = { version = "0.10", default-features = false, features = ["groups", "pairings", "experimental"], package = "ic_bls12_381" }
 pairing = "0.23"
 sha2 = { version = "0.10", default-features = false }
-rand = { version = "0.8", default-features = false }
+rand = { version = "0.8", default-features = false, optional = true }
 
 lazy_static = { version = "1", optional = true }
 hex = { version = "0.4", optional = true, default-features = false }
 
 [features]
-default = ["alloc"]
+default = ["alloc", "rand"]
+rand = ["dep:rand"]
 alloc = ["bls12_381/alloc", "lazy_static", "hex/alloc"]
 
 [dev-dependencies]

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,8 @@
 
+# 0.6 - 2024-08-09
+
+* Gate use of `rand` behind feature "rand"
+
 # 0.5 - 2024-07-17
 
 * Bump `ic_bls12_381` dependency to 0.10

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@ use core::fmt;
 use bls12_381::hash_to_curve::{ExpandMsgXmd, HashToCurve};
 use bls12_381::{G1Affine, G1Projective, G2Affine, Scalar};
 use pairing::group::Curve;
-use rand::{CryptoRng, RngCore};
 
 #[cfg(feature = "alloc")]
 use core::ops::Neg;
@@ -211,7 +210,8 @@ impl PrivateKey {
     }
 
     /// Create a new random secret key using specified RNG
-    pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
+    #[cfg(feature = "rand")]
+    pub fn random<R: rand::RngCore + rand::CryptoRng>(rng: &mut R) -> Self {
         loop {
             let mut buf = [0u8; 32];
             rng.fill_bytes(&mut buf);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -68,6 +68,7 @@ fn reject_invalid_key() {
 }
 
 #[test]
+#[cfg(feature = "rand")]
 fn accepts_generated_signatures() {
     use rand::Rng;
 
@@ -87,6 +88,7 @@ fn accepts_generated_signatures() {
 }
 
 #[test]
+#[cfg(feature = "rand")]
 fn random_keys_are_random() {
     let mut rng = rand::thread_rng();
 


### PR DESCRIPTION
This allows for easy compilation to wasm by avoiding the getrandom dependency.